### PR TITLE
Fix whitespace on stash output

### DIFF
--- a/agnosterzak.zsh-theme
+++ b/agnosterzak.zsh-theme
@@ -252,7 +252,7 @@ prompt_git() {
 
     local number_of_stashes="$(git stash list -n1 2> /dev/null | wc -l)"
     if [[ $number_of_stashes -gt 0 ]]; then
-      stashed=" $number_of_stashes⚙"
+      stashed=" ${number_of_stashes##*(  )}⚙"
       bgclr='magenta'
       fgclr='white'
     fi


### PR DESCRIPTION
- This will fix unnecessary whitespace on the prompt when some code is stashed.
- Thanks to https://www.cyberciti.biz/faq/bash-remove-whitespace-from-string/