### PR TITLE
Give some space aroung Git prompt

### DIFF
--- a/agnosterzak.zsh-theme
+++ b/agnosterzak.zsh-theme
@@ -289,7 +289,7 @@ prompt_git() {
 
     prompt_segment $bgclr $fgclr
 
-    echo -n "%{$fg_bold[$fgclr]%}${ref/refs\/heads\//$PL_BRANCH_CHAR $upstream_prompt}${mode}$to_push$to_pull$clean$tagged$stashed$untracked$modified$deleted$added$ready_commit%{$fg_no_bold[$fgclr]%}"
+    echo -n " %{$fg_bold[$fgclr]%}${ref/refs\/heads\//$PL_BRANCH_CHAR $upstream_prompt}${mode}$to_push$to_pull$clean$tagged$stashed$untracked$modified$deleted$added$ready_commit%{$fg_no_bold[$fgclr]%} "
   fi
 }
 


### PR DESCRIPTION
- Right now the Git part of the prompt do not have any spaces around.
- The official Agnoster theme has spaces around, which looks better.
- So adding some space around the Git part of the prompt.